### PR TITLE
fix: 解决maxSize属性设置与生成图片尺寸不符问题,计算错误。

### DIFF
--- a/harmony/rnoh_signature_capture/src/main/ets/SignatureCaptureArk.ets
+++ b/harmony/rnoh_signature_capture/src/main/ets/SignatureCaptureArk.ets
@@ -177,19 +177,21 @@ export struct SignatureCaptureArkView {
   private getReSizePm() {
     const pm = this.getCanvasPixMap();
     const maxSize = this.descriptorWrapper.props.maxSize;
-    let width = this.context2D.width;
-    let height = this.context2D.height;
-    const ratio = width / height;
-    if (ratio > 1) {
-      width = maxSize;
-      height = width / ratio;
-    } else {
-      height = maxSize;
-      width = height * ratio;
+    if (maxSize) {
+      let width = this.context2D.width;
+      let height = this.context2D.height;
+      const ratio = width / height;
+      if (ratio > 1) {
+        width = maxSize;
+        height = width / ratio;
+      } else {
+        height = maxSize;
+        width = height * ratio;
+      }
+      let xScale = width / this.context2D.width / 3.25;
+      let yScale = height / this.context2D.height / 3.25;
+      pm.scaleSync(xScale, yScale);
     }
-    let xScale = width / this.context2D.width;
-    let yScale = height / this.context2D.height;
-    pm.scaleSync(xScale, yScale);
     return pm;
   }
 

--- a/src/SignatureCaptureNativeComponent.ts
+++ b/src/SignatureCaptureNativeComponent.ts
@@ -18,7 +18,7 @@ export interface OutgoingAndIncomingData {
     showBorder?: WithDefault<boolean, true>,
     showNativeButtons?: WithDefault<boolean, true>,
     showTitleLabel?: WithDefault<boolean, true>,
-    maxSize?: WithDefault<Int32, 500>,
+    maxSize?: Int32,
     minStrokeWidth?: WithDefault<Float, 3>,
     maxStrokeWidth?: WithDefault<Float, 6>,
     strokeColor?: ProcessedColorValue | null,


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

@close #10 

- 这个 PR 解决了 #10 
- 主要是处理maxSize属性计算错误，生成的图片大小不正确。
- 计算时宽高的scale值都应该除以3.25


## Test Plan

测试用例路径：https://github.com/react-native-oh-library/RNOHDCS/blob/main/react-native-signature-capture/signatureCapture.tsx


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [X] 更新了 JS/TS 代码
