### PR TITLE
#20该三方库与react-native-orientation-locker库一起使用时强制横屏失败

### DIFF
--- a/harmony/rnoh_signature_capture/src/main/ets/SignatureCaptureArk.ets
+++ b/harmony/rnoh_signature_capture/src/main/ets/SignatureCaptureArk.ets
@@ -128,9 +128,11 @@ export struct SignatureCaptureArkView {
 
   private onDescriptorWrapperChange(descriptor: RNC.RSSignatureArkView.Descriptor) {
     this.logger.info('descriptor change!');
+    // 保存上一次的viewMode
     const prevViewMode = this.descriptorWrapper?.props?.viewMode;
     this.descriptorWrapper = new RNC.RSSignatureArkView.DescriptorWrapper(descriptor);
     this.setProps();
+    // 如果上一次的横竖屏情况与新的横竖屏情况没有发生变化，就不调用设置横竖屏的回调
     if (prevViewMode !== this.descriptorWrapper.props.viewMode) {
       this.setViewMode(this.descriptorWrapper.props.viewMode);
     }

--- a/harmony/rnoh_signature_capture/src/main/ets/SignatureCaptureArk.ets
+++ b/harmony/rnoh_signature_capture/src/main/ets/SignatureCaptureArk.ets
@@ -89,7 +89,6 @@ export struct SignatureCaptureArkView {
     this.setMaxWidth();
     this.setStrokeColor();
     this.setBackgroundColor();
-    this.setViewMode(this.descriptorWrapper.props.viewMode);
   }
 
   private async setWindowClass(): Promise<void> {
@@ -129,8 +128,12 @@ export struct SignatureCaptureArkView {
 
   private onDescriptorWrapperChange(descriptor: RNC.RSSignatureArkView.Descriptor) {
     this.logger.info('descriptor change!');
+    const prevViewMode = this.descriptorWrapper?.props?.viewMode;
     this.descriptorWrapper = new RNC.RSSignatureArkView.DescriptorWrapper(descriptor);
     this.setProps();
+    if (prevViewMode !== this.descriptorWrapper.props.viewMode) {
+      this.setViewMode(this.descriptorWrapper.props.viewMode);
+    }
   }
 
   aboutToDisappear() {


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
- #20
- 这个功能是什么？（如果适用）
使该三方库与react-native-orientation-locker库一起使用时可以强制横屏或者强制竖屏
- 您是如何实现解决方案的？
在监听属性变化的地方判断如果设置三方库横屏竖屏的属性值没有变化时，就不调用设置横屏竖屏的方法
- 这个更改影响了库的哪些部分？
- 用户传的横竖屏没有发生变化时，不调用该库中的设置横竖屏的回调

Explain the **motivation** for making this change: here are some points to help you:


## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->

